### PR TITLE
[feature]: 역할(Role)에 따른 회원가입 분기 및 승인 처리 로직 구현

### DIFF
--- a/src/main/java/com/fourirbnb/user/application/dto/ApprovalUserInternalRequest.java
+++ b/src/main/java/com/fourirbnb/user/application/dto/ApprovalUserInternalRequest.java
@@ -1,0 +1,24 @@
+package com.fourirbnb.user.application.dto;
+
+import com.fourirbnb.user.domain.entity.ApprovalStatus;
+import com.fourirbnb.user.domain.entity.Role;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ApprovalUserInternalRequest {
+
+  private String email;
+  private String password;
+  private String nickname;
+  private String username;
+  private String slackId;
+  private String phone;
+  private Role role;
+  private ApprovalStatus status;
+}

--- a/src/main/java/com/fourirbnb/user/application/mapper/AdminMapper.java
+++ b/src/main/java/com/fourirbnb/user/application/mapper/AdminMapper.java
@@ -1,0 +1,49 @@
+package com.fourirbnb.user.application.mapper;
+
+import com.fourirbnb.user.domain.entity.Admin;
+import com.fourirbnb.user.domain.entity.ApprovalStatus;
+import com.fourirbnb.user.domain.entity.Staging;
+import com.fourirbnb.user.presentation.dto.CreateUserInternalRequest;
+import com.fourirbnb.user.presentation.dto.UserResponseDto;
+
+public class AdminMapper {
+
+  public static Admin toEntity(CreateUserInternalRequest request) {
+    return new Admin(
+        request.getEmail(),
+        request.getPassword(),
+        request.getNickname(),
+        request.getUsername(),
+        request.getPhone(),
+        request.getSlackId(),
+        request.getRole(),
+        ApprovalStatus.APPROVED
+    );
+  }
+
+  public static Admin toEntity(Staging staging) {
+    return new Admin(
+        staging.getEmail(),
+        staging.getPassword(),
+        staging.getNickname(),
+        staging.getUsername(),
+        staging.getPhone(),
+        staging.getSlackId(),
+        staging.getRole(),
+        ApprovalStatus.APPROVED
+    );
+  }
+
+  public static UserResponseDto toResponse(Admin admin) {
+    return new UserResponseDto(
+        admin.getId(),
+        admin.getEmail(),
+        admin.getPassword(),
+        admin.getNickname(),
+        admin.getPhone(),
+        admin.getSlackId(),
+        admin.getUsername(),
+        admin.getRole()
+    );
+  }
+}

--- a/src/main/java/com/fourirbnb/user/application/mapper/StagingMapper.java
+++ b/src/main/java/com/fourirbnb/user/application/mapper/StagingMapper.java
@@ -1,0 +1,20 @@
+package com.fourirbnb.user.application.mapper;
+
+import com.fourirbnb.user.domain.entity.Staging;
+import com.fourirbnb.user.presentation.dto.StagingResponseDto;
+
+public class StagingMapper {
+
+  public static StagingResponseDto toResponse(Staging staging) {
+    return new StagingResponseDto(
+        staging.getId(),
+        staging.getEmail(),
+        staging.getUsername(),
+        staging.getNickname(),
+        staging.getPhone(),
+        staging.getSlackId(),
+        staging.getRole(),
+        staging.getStatus()
+    );
+  }
+}

--- a/src/main/java/com/fourirbnb/user/application/mapper/UserMapper.java
+++ b/src/main/java/com/fourirbnb/user/application/mapper/UserMapper.java
@@ -1,5 +1,8 @@
 package com.fourirbnb.user.application.mapper;
 
+import com.fourirbnb.user.application.dto.ApprovalUserInternalRequest;
+import com.fourirbnb.user.domain.entity.ApprovalStatus;
+import com.fourirbnb.user.domain.entity.Staging;
 import com.fourirbnb.user.domain.entity.User;
 import com.fourirbnb.user.presentation.dto.CreateUserInternalRequest;
 import com.fourirbnb.user.presentation.dto.UserInternalResponse;
@@ -16,7 +19,8 @@ public class UserMapper {
         request.getUsername(),
         request.getPhone(),
         request.getSlackId(),
-        request.getRole()
+        request.getRole(),
+        ApprovalStatus.APPROVED
     );
   }
 
@@ -40,5 +44,45 @@ public class UserMapper {
     );
   }
 
+  public static ApprovalUserInternalRequest withStatus(CreateUserInternalRequest request,
+      ApprovalStatus status) {
+    return ApprovalUserInternalRequest.builder()
+        .email(request.getEmail())
+        .password(request.getPassword())
+        .nickname(request.getNickname())
+        .username(request.getUsername())
+        .slackId(request.getSlackId())
+        .phone(request.getPhone())
+        .role(request.getRole())
+        .status(status)
+        .build();
+  }
+
+  public static Staging toStagingEntity(ApprovalUserInternalRequest request) {
+    return new Staging(
+        request.getEmail(),
+        request.getPassword(),
+        request.getUsername(),
+        request.getNickname(),
+        request.getSlackId(),
+        request.getPhone(),
+        request.getRole(),
+        request.getStatus()
+    );
+
+  }
+
+  public static User toEntity(Staging staging) {
+    return new User(
+        staging.getEmail(),
+        staging.getPassword(),
+        staging.getNickname(),
+        staging.getUsername(),
+        staging.getPhone(),
+        staging.getSlackId(),
+        staging.getRole(),
+        ApprovalStatus.APPROVED
+    );
+  }
 
 }

--- a/src/main/java/com/fourirbnb/user/application/service/UserService.java
+++ b/src/main/java/com/fourirbnb/user/application/service/UserService.java
@@ -2,14 +2,24 @@ package com.fourirbnb.user.application.service;
 
 import com.fourirbnb.common.exception.InvalidParameterException;
 import com.fourirbnb.common.exception.ResourceNotFoundException;
+import com.fourirbnb.user.application.mapper.AdminMapper;
+import com.fourirbnb.user.application.mapper.StagingMapper;
 import com.fourirbnb.user.application.mapper.UserMapper;
+import com.fourirbnb.user.domain.entity.Admin;
+import com.fourirbnb.user.domain.entity.ApprovalStatus;
+import com.fourirbnb.user.domain.entity.Role;
+import com.fourirbnb.user.domain.entity.Staging;
 import com.fourirbnb.user.domain.entity.User;
+import com.fourirbnb.user.domain.repository.AdminRepository;
+import com.fourirbnb.user.domain.repository.StagingRepository;
 import com.fourirbnb.user.domain.repository.UserRepository;
 import com.fourirbnb.user.presentation.dto.CreateUserInternalRequest;
+import com.fourirbnb.user.presentation.dto.StagingResponseDto;
 import com.fourirbnb.user.presentation.dto.UpdateUserRequest;
 import com.fourirbnb.user.presentation.dto.UserInternalResponse;
 import com.fourirbnb.user.presentation.dto.UserResponseDto;
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -23,6 +33,8 @@ public class UserService {
 
 
   private final UserRepository userRepository;
+  private final StagingRepository stagingRepository;
+  private final AdminRepository adminRepository;
 
   //캐싱 적용예정
   @Transactional(readOnly = true)
@@ -46,13 +58,45 @@ public class UserService {
         .collect(Collectors.toList());
   }
 
+  /*
+   실무적으로 생각을 해보았을때 admin 과 user 의 도메인을 분리하고
+   각기 다른 DTO/서비스로 나누는 것이 이상적이지만
+   구현 복잡도와 프로젝트 리소스를 고려해
+   현재는 동일한 필드를 기준으로 하나의 흐름으로 처리하였습니다.
+   또한 프로젝트 범위에서는 회원가입 로직만 분리 구현하였고
+   수정/삭제 등 나머지 기능은 공통 흐름으로 처리하거나 생략했습니다.
+
+   추후 확장 시 AdminService 에 CRUD 를 분리 구현할 수 있습니다.
+ */
   @Transactional
   public void createUser(CreateUserInternalRequest request) {
-    //유저 이메일 검증
-    if (userRepository.existsByEmail(request.getEmail())) {
-      throw new InvalidParameterException("이미 가입된 이메일입니다.");
+    System.out.println(request.getRole() + "서비스 권한");
+    if (request.getRole() == Role.HOST || request.getRole() == Role.MANAGER) {
+      //승인 대기소
+      if (stagingRepository.existsByEmailAndStatusIn(
+          request.getEmail(),
+          List.of(ApprovalStatus.PENDING, ApprovalStatus.APPROVED)
+      )) {
+        throw new InvalidParameterException("이미 가입되었거나 승인 대기 중인 이메일입니다.");
+      }
+      //Staging 저장
+      stagingRepository.save(
+          UserMapper.toStagingEntity(UserMapper.withStatus(request, ApprovalStatus.PENDING)));
+    } else if (request.getRole() == Role.CUSTOMER) {
+      //CUSTOMER
+      if (userRepository.existsByEmail(request.getEmail())) {
+        throw new InvalidParameterException("이미 가입된 이메일입니다.");
+      }
+      userRepository.save(UserMapper.toEntity(request));
+    } else if (request.getRole() == Role.MASTER) {
+      //MASTER
+      if (adminRepository.existsByEmail(request.getEmail())) {
+        throw new InvalidParameterException("이미 가입된 이메일입니다.");
+      }
+      adminRepository.save(AdminMapper.toEntity(request));
+    } else {
+      throw new InvalidParameterException("지원하지 않는 역할입니다.");
     }
-    userRepository.save(UserMapper.toEntity(request));
   }
 
   @Transactional
@@ -81,8 +125,45 @@ public class UserService {
     user.updatePassword(encodedPassword);
   }
 
+  @Transactional(readOnly = true)
+  public UserResponseDto getAdminByEmail(String email) {
+    Admin checkUser = adminRepository.findByEmail(email)
+        .orElseThrow(() -> new ResourceNotFoundException("회원을 찾을 수 없습니다."));
+    return AdminMapper.toResponse(checkUser);
+  }
+
+
   private User findUserByIdOrThrow(Long id) {
     return userRepository.findById(id)
         .orElseThrow(() -> new ResourceNotFoundException("회원을 찾을 수 없습니다."));
   }
+
+  @Transactional(readOnly = true)
+  public List<StagingResponseDto> findPendingStagingUsers() {
+    List<Staging> pendingList = stagingRepository.findAllByStatus(ApprovalStatus.PENDING);
+    return pendingList.stream()
+        .map(StagingMapper::toResponse)
+        .collect(Collectors.toList());
+  }
+
+  @Transactional
+  public void approveStagingUser(UUID stagingId) {
+    Staging staging = stagingRepository.findById(stagingId)
+        .orElseThrow(() -> new ResourceNotFoundException("승인 대기 유저를 찾을 수 없습니다."));
+    if (staging.getStatus() != ApprovalStatus.PENDING) {
+      throw new InvalidParameterException("이미 승인된 사용자입니다.");
+    }
+
+    //이관 작업
+    if (staging.getRole() == Role.HOST) {
+      userRepository.save(UserMapper.toEntity(staging));
+    } else if (staging.getRole() == Role.MANAGER) {
+      adminRepository.save(AdminMapper.toEntity(staging));
+    } else {
+      throw new InvalidParameterException("승인할 수 없는 역할입니다.");
+    }
+    //승인 업데이트
+    staging.updateStatus(ApprovalStatus.APPROVED);
+  }
+
 }

--- a/src/main/java/com/fourirbnb/user/domain/entity/Admin.java
+++ b/src/main/java/com/fourirbnb/user/domain/entity/Admin.java
@@ -1,8 +1,6 @@
 package com.fourirbnb.user.domain.entity;
 
-
 import com.fourirbnb.common.domain.BaseEntity;
-import com.fourirbnb.user.presentation.dto.UpdateUserRequest;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -11,15 +9,14 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
-import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Entity
 @Getter
-@Table(name = "p_user")
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class User extends BaseEntity {
+@NoArgsConstructor
+@Entity
+@Table(name = "p_admin")
+public class Admin extends BaseEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -50,26 +47,17 @@ public class User extends BaseEntity {
   @Enumerated(EnumType.STRING)
   private ApprovalStatus approvalStatus;
 
-  public User(String email, String password, String nickname, String username, String phone,
+  public Admin(String email, String password, String nickname, String username, String phone,
       String slackId, Role role, ApprovalStatus status) {
     this.email = email;
     this.password = password;
-    this.nickname = nickname;
     this.username = username;
+    this.nickname = nickname;
     this.phone = phone;
-    this.slackId = slackId;
     this.role = role;
+    this.slackId = slackId;
     this.approvalStatus = status;
   }
 
 
-  public void update(UpdateUserRequest request) {
-    this.nickname = request.getNickname();
-    this.phone = request.getPhone();
-    this.slackId = request.getSlackId();
-  }
-
-  public void updatePassword(String encodedPassword) {
-    this.password = encodedPassword;
-  }
 }

--- a/src/main/java/com/fourirbnb/user/domain/entity/ApprovalStatus.java
+++ b/src/main/java/com/fourirbnb/user/domain/entity/ApprovalStatus.java
@@ -1,0 +1,5 @@
+package com.fourirbnb.user.domain.entity;
+
+public enum ApprovalStatus {
+  PENDING, APPROVED, REJECTED
+}

--- a/src/main/java/com/fourirbnb/user/domain/entity/Staging.java
+++ b/src/main/java/com/fourirbnb/user/domain/entity/Staging.java
@@ -1,0 +1,64 @@
+package com.fourirbnb.user.domain.entity;
+
+import com.fourirbnb.common.domain.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.util.UUID;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@Table(name = "p_staging")
+public class Staging extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.AUTO)
+  @Column(updatable = false, nullable = false)
+  public UUID id;
+
+  @Column(nullable = false)
+  public String email;
+
+  @Column(nullable = false)
+  public String password;
+
+  public String username;
+
+  public String nickname;
+
+  public String slackId;
+
+  public String phone;
+
+  @Column(nullable = false)
+  @Enumerated(EnumType.STRING)
+  public Role role;
+
+  @Column(nullable = false)
+  @Enumerated(EnumType.STRING)
+  public ApprovalStatus status;
+
+  public Staging(String email, String password, String username, String nickname,
+      String slackId, String phone, Role role, ApprovalStatus status) {
+    this.email = email;
+    this.password = password;
+    this.username = username;
+    this.nickname = nickname;
+    this.slackId = slackId;
+    this.phone = phone;
+    this.role = role;
+    this.status = status;
+  }
+
+  public void updateStatus(ApprovalStatus approvalStatus) {
+    this.status = approvalStatus;
+  }
+}

--- a/src/main/java/com/fourirbnb/user/domain/repository/AdminRepository.java
+++ b/src/main/java/com/fourirbnb/user/domain/repository/AdminRepository.java
@@ -1,0 +1,12 @@
+package com.fourirbnb.user.domain.repository;
+
+import com.fourirbnb.user.domain.entity.Admin;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AdminRepository extends JpaRepository<Admin, Long> {
+
+  boolean existsByEmail(String email);
+
+  Optional<Admin> findByEmail(String email);
+}

--- a/src/main/java/com/fourirbnb/user/domain/repository/StagingRepository.java
+++ b/src/main/java/com/fourirbnb/user/domain/repository/StagingRepository.java
@@ -1,0 +1,17 @@
+package com.fourirbnb.user.domain.repository;
+
+import com.fourirbnb.user.domain.entity.ApprovalStatus;
+import com.fourirbnb.user.domain.entity.Staging;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StagingRepository extends JpaRepository<Staging, UUID> {
+
+  boolean existsByEmail(String email);
+
+  boolean existsByEmailAndStatusIn(
+      String email, List<ApprovalStatus> pending);
+
+  List<Staging> findAllByStatus(ApprovalStatus approvalStatus);
+}

--- a/src/main/java/com/fourirbnb/user/presentation/controller/AdminInternalController.java
+++ b/src/main/java/com/fourirbnb/user/presentation/controller/AdminInternalController.java
@@ -1,0 +1,57 @@
+package com.fourirbnb.user.presentation.controller;
+
+import com.fourirbnb.common.exception.InvalidParameterException;
+import com.fourirbnb.user.application.service.UserService;
+import com.fourirbnb.user.presentation.dto.CreateUserInternalRequest;
+import com.fourirbnb.user.presentation.dto.StagingResponseDto;
+import com.fourirbnb.user.presentation.dto.UserResponseDto;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/internal/users/admin")
+@RestController
+@RequiredArgsConstructor
+public class AdminInternalController {
+
+  private final UserService userService;
+
+  @PostMapping("/signUp")
+  public ResponseEntity<?> adminSignUp(@RequestBody CreateUserInternalRequest request) {
+    try {
+      System.out.println("어드민 들어옴");
+      System.out.println(request.getRole() + "권한");
+      userService.createUser(request);
+      return ResponseEntity.status(HttpStatus.CREATED).build();
+    } catch (InvalidParameterException e) {
+      return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
+    }
+  }
+
+  @GetMapping("/{email}")
+  public ResponseEntity<UserResponseDto> findByAdmin(@PathVariable String email) {
+    UserResponseDto dto = userService.getAdminByEmail(email);
+    return ResponseEntity.ok(dto);
+  }
+
+  @GetMapping("/approve")
+  public ResponseEntity<List<StagingResponseDto>> findByAdminApprove() {
+    List<StagingResponseDto> pendingUsers = userService.findPendingStagingUsers();
+    return ResponseEntity.ok(pendingUsers);
+  }
+
+  @PatchMapping("/approve/{stagingId}")
+  public ResponseEntity<?> approve(@PathVariable UUID stagingId) {
+    userService.approveStagingUser(stagingId);
+    return ResponseEntity.ok().build();
+  }
+}

--- a/src/main/java/com/fourirbnb/user/presentation/controller/UserInternalController.java
+++ b/src/main/java/com/fourirbnb/user/presentation/controller/UserInternalController.java
@@ -3,6 +3,7 @@ package com.fourirbnb.user.presentation.controller;
 import com.fourirbnb.common.exception.InvalidParameterException;
 import com.fourirbnb.user.application.service.UserService;
 import com.fourirbnb.user.presentation.dto.CreateUserInternalRequest;
+import com.fourirbnb.user.presentation.dto.UpdatePasswordRequest;
 import com.fourirbnb.user.presentation.dto.UserInternalResponse;
 import com.fourirbnb.user.presentation.dto.UserResponseDto;
 import lombok.RequiredArgsConstructor;
@@ -36,12 +37,25 @@ public class UserInternalController {
     return ResponseEntity.ok(dto);
   }
 
-  //request 다시 검증이 필요할까?
+
   @PostMapping("/signUp")
   public ResponseEntity<?> userSignUp(
       @RequestBody CreateUserInternalRequest request) {
     try {
       userService.createUser(request);
+      return ResponseEntity.status(HttpStatus.CREATED).build();
+    } catch (InvalidParameterException e) {
+      return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
+    }
+  }
+
+  @PostMapping("/saveStaging")
+  public ResponseEntity<?> saveStagingRequest(@RequestBody CreateUserInternalRequest feignRequest) {
+    try {
+      System.out.println("feign 넘어옴 시작");
+      System.out.println(feignRequest.getRole() + "요청값");
+      userService.createUser(feignRequest);
+      System.out.println("끝남");
       return ResponseEntity.status(HttpStatus.CREATED).build();
     } catch (InvalidParameterException e) {
       return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
@@ -57,8 +71,8 @@ public class UserInternalController {
 
   @GetMapping("/updatePassword")
   public ResponseEntity<Void> updatePassword(
-      Long id, String password) {
-    userService.updatePassword(id, password);
+      @RequestBody UpdatePasswordRequest request) {
+    userService.updatePassword(request.getId(), request.getPassword());
     return ResponseEntity.status(HttpStatus.CREATED).build();
   }
 

--- a/src/main/java/com/fourirbnb/user/presentation/dto/StagingResponseDto.java
+++ b/src/main/java/com/fourirbnb/user/presentation/dto/StagingResponseDto.java
@@ -1,0 +1,18 @@
+package com.fourirbnb.user.presentation.dto;
+
+import com.fourirbnb.user.domain.entity.ApprovalStatus;
+import com.fourirbnb.user.domain.entity.Role;
+import java.util.UUID;
+
+public record StagingResponseDto(
+    UUID id,
+    String email,
+    String username,
+    String nickname,
+    String phone,
+    String slackId,
+    Role role,
+    ApprovalStatus status
+) {
+
+}

--- a/src/main/java/com/fourirbnb/user/presentation/dto/UpdatePasswordRequest.java
+++ b/src/main/java/com/fourirbnb/user/presentation/dto/UpdatePasswordRequest.java
@@ -1,0 +1,16 @@
+package com.fourirbnb.user.presentation.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdatePasswordRequest {
+
+  private Long id;
+  private String password;
+}


### PR DESCRIPTION
## ✨ 변경 타입
* [x] 신규 기능 추가/수정
* [ ] 버그 수정
* [x] 리팩토링
* [ ] 설정
* [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## ✅ 체크리스트

* [x] 코드 작성 가이드라인을 준수했는가?
* [x] 변경 사항에 대한 테스트를 완료했는가?
* [x] 문서 변경이 필요한 경우, 해당 내용을 반영했는가?

## 🚀 PR 내용

* **한 줄 요약**
    * 사용자 역할(Role)에 따라 가입 대상 분기 및 승인 흐름 설계 및 구현

* **세부 내용**
    * `CUSTOMER`, `HOST`, `MANAGER`, `MASTER` 등 역할에 따라 저장 대상이 달라지도록 분기 처리
        - `CUSTOMER`: 일반 사용자 → 바로 `User` 테이블에 저장
        - `HOST`, `MANAGER`: 승인 대상 → `Staging` 테이블에 `PENDING` 상태로 저장
        - `MASTER`: 어드민 권한 → `Admin` 테이블에 즉시 저장

    * 승인 처리 흐름 구현
        - `/internal/admin/approve/{uuid}` 호출 시 승인 처리
        - `HOST`는 `User` 테이블, `MANAGER`는 `Admin` 테이블로 이관
        - 승인 후 `Staging.status`를 `APPROVED`로 업데이트 (승인 이력 보존 목적)

    * 중복 가입 및 승인 중복 방지
        - 이메일 기준 중복 체크
        - `Staging` 테이블에서 `PENDING` 또는 `APPROVED` 상태 존재 시 가입 거부

    * 승인 대기자 조회 API 추가
        - `/internal/admin/approve` 호출 시 `PENDING` 상태의 승인 대기 목록 반환
        - `StagingResponseDto`를 통해 응답

    * 엔티티, DTO, Mapper, Service 등 전체 역할 기반 구조 리팩토링
        - `User`, `Admin`, `Staging` 엔티티 분리
        - `UserMapper`, `AdminMapper` 에 `Staging → Entity` 변환 메서드 추가
        - `ApprovalStatus` Enum 도입

    * 실무 기준 설계 고려
        - 도메인에 따라 엔티티는 분리했으나, DTO는 리소스와 통합성 유지 목적상 단일 구조 유지
        - 구조 분리 의도와 현실적인 구현 트레이드오프를 주석으로 명시 처리

---

## 🧪 테스트 시나리오 요약

- `CUSTOMER` 회원가입 → 즉시 User DB 저장됨
- `HOST`, `MANAGER` → Staging 테이블에 저장됨
- 승인 요청(PATCH) 시 정상 이관됨 + 상태 APPROVED로 변경됨
- 승인 대기 목록 GET 요청 시 PENDING만 필터링되어 반환됨
- 중복 이메일 요청 시 예외 발생 확인됨